### PR TITLE
MGF-1597-feat(review): Limit student address and related fields to 170 characters.

### DIFF
--- a/app/views/dashboard/internship_agreements/multi/_multi_school_management_form_fields.html.slim
+++ b/app/views/dashboard/internship_agreements/multi/_multi_school_management_form_fields.html.slim
@@ -216,6 +216,7 @@ tbody.internship-agreement
                            content: content,
                            title: title,
                            filled_by: filled_by,
+                           limit: 170,
                            disabled: disabled }
 
       .row.mt-0

--- a/app/views/dashboard/internship_agreements/shared/_school_management_form_fields.html.slim
+++ b/app/views/dashboard/internship_agreements/shared/_school_management_form_fields.html.slim
@@ -215,6 +215,7 @@ tbody.internship-agreement
                            text_label: label,
                            content: content,
                            title: title,
+                           limit: 170,
                            filled_by: filled_by,
                            disabled: disabled }
 

--- a/app/views/internship_applications/_form.html.slim
+++ b/app/views/internship_applications/_form.html.slim
@@ -136,7 +136,7 @@ div data-controller="mandatory-fields internship-application-form" data-mandator
                     value: f.object.student_address ||f.object.student.address,
                     label: "Votre adresse postale complète",
                     options: { required: true,
-                               maxlength: 300,
+                               maxlength: 170,
                                data: {:'mandatory-fields-target' => "mandatoryField",
                                       action: "input->mandatory-fields#fieldChange"} },
                     required: true,

--- a/db/migrate/20260420123136_reduce_student_address_size.rb
+++ b/db/migrate/20260420123136_reduce_student_address_size.rb
@@ -1,0 +1,5 @@
+class ReduceStudentAddressSize < ActiveRecord::Migration[7.2]
+  def change
+    change_column :internship_agreements, :student_address, :string, limit: 170
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -17,10 +17,24 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
 
 
 --
+-- Name: EXTENSION pg_trgm; Type: COMMENT; Schema: -; Owner: -
+--
+
+-- COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
+
+
+--
 -- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
 --
 
 CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pgcrypto; Type: COMMENT; Schema: -; Owner: -
+--
+
+-- COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 
 
 --
@@ -31,10 +45,24 @@ CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA public;
 
 
 --
+-- Name: EXTENSION postgis; Type: COMMENT; Schema: -; Owner: -
+--
+
+-- COMMENT ON EXTENSION postgis IS 'PostGIS geometry and geography spatial types and functions';
+
+
+--
 -- Name: unaccent; Type: EXTENSION; Schema: -; Owner: -
 --
 
 CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION unaccent; Type: COMMENT; Schema: -; Owner: -
+--
+
+-- COMMENT ON EXTENSION unaccent IS 'text search dictionary that removes accents';
 
 
 --
@@ -5343,6 +5371,7 @@ ALTER TABLE ONLY public.class_rooms
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260420123136'),
 ('20260309162833'),
 ('20260306100239'),
 ('20260203214306'),
@@ -5843,4 +5872,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190215085127'),
 ('20190212163331'),
 ('20190207111844');
-


### PR DESCRIPTION
This commit reduces the maximum size of the `student_address` field in the database and updates related views and forms to reflect this change. The fields affected are those where an address is input by a user, such as the "Votre adresse postale complète" field in the internship application form.