### PR TITLE
fix(MGF-1554): remove broken FAQ links on homepages

### DIFF
--- a/app/views/pages/home/everyone/_everyone_faq.html.slim
+++ b/app/views/pages/home/everyone/_everyone_faq.html.slim
@@ -14,9 +14,3 @@
           .fr-tile__header
             .fr-tile__pictogram
               = image_tag asset_pack_path('media/images/homepage/school.svg'), alt: "Élèves", width: '40px', height: '40px'
-
-  .row.fr-my-3w
-    .col-12.text-center
-      = link_to 'Voir toutes les questions fréquentes',
-                'https://www.education.gouv.fr/reussir-au-lycee/un-stage-en-juin-pour-les-eleves-de-seconde-generale-et-technologique-380196',
-                class: 'fr-btn fr-btn--secondary', target: '_blank'

--- a/app/views/pages/home/school_management/_faq_school_management.html.slim
+++ b/app/views/pages/home/school_management/_faq_school_management.html.slim
@@ -3,10 +3,3 @@ h4.text-dark Foire aux questions
 = render 'pages/home/everyone/faq_in_cards',
            target: 'éducation',
            klass: 'fr-badge--no-icon fr-badge--info'
-
-.row.fr-py-3w
-  .col-12.text-center
-    = link_to 'Voir toutes les questions fréquentes',
-              'https://www.education.gouv.fr/reussir-au-lycee/un-stage-en-juin-pour-les-eleves-de-seconde-generale-et-technologique-380196',
-              class: 'fr-btn fr-btn--secondary',
-              target: '_blank'

--- a/app/views/pages/home/statisticians/_faq_statistician.html.slim
+++ b/app/views/pages/home/statisticians/_faq_statistician.html.slim
@@ -3,9 +3,3 @@ h4.text-dark Questions fréquentes
            target: 'Référents',
            klass: 'fr-badge--purple-glycine'
 
-.row.fr-my-3w
-  .col-12.text-center
-    = link_to 'Voir toutes les questions fréquentes',
-              'https://www.education.gouv.fr/reussir-au-lycee/un-stage-en-juin-pour-les-eleves-de-seconde-generale-et-technologique-380196',
-              class: 'fr-btn fr-btn--secondary',
-              target: '_blank'


### PR DESCRIPTION
The links to the FAQ pages were updated with a new URL. This fix ensures that users can access the FAQ content correctly.