### PR TITLE
MGFF-1638 - emails for school_managers

### DIFF
--- a/app/libs/services/employer_actions/resolver.rb
+++ b/app/libs/services/employer_actions/resolver.rb
@@ -8,7 +8,6 @@ module Services::EmployerActions
         extra_resolver(user_id:, urgency_level:)
         standard_resolver(user_id:, urgency_level:)
       end
-
       MailActionItem.for_user(user_id)
                     .resolved
                     .delete_all
@@ -39,7 +38,7 @@ module Services::EmployerActions
                               .where(urgency_level:)
                               .where(action_name: "canceled_internship_application_by_student")
       actions.present? && actions.each do |item|
-        if item&.internship_application&.canceled_by_student_confirmation?
+        unless item&.internship_application&.canceled_by_student?
           application_resolve(item.internship_application)
         end
       end
@@ -64,7 +63,7 @@ module Services::EmployerActions
         action_name: "cancel_by_student_confirmation"
       )
       actions.present? && actions.each do |item|
-        if item&.internship_application&.canceled_by_student_confirmation?
+        if !item&.internship_application&.canceled_by_student_confirmation?
           application_resolve(item.internship_application)
         end
       end

--- a/app/libs/services/employer_actions/resolver.rb
+++ b/app/libs/services/employer_actions/resolver.rb
@@ -74,6 +74,18 @@ module Services::EmployerActions
       # =======================================================
 
       # ------------------------
+      # new_agreement_to_fill_in case
+      # ------------------------
+      new_agreement_to_fill_in_items = MailActionItem.for_user(user_id)
+                                                     .where(urgency_level:)
+                                                     .where(action_name: "new_agreement_to_fill_in")
+      new_agreement_to_fill_in_items.present? && new_agreement_to_fill_in_items.each do |item|
+        do_not_resolve_conditions = item&.internship_agreement&.kept? &&
+                                    item.internship_agreement&.draft?
+        agreement_resolve(item.internship_agreement) unless do_not_resolve_conditions
+      end
+
+      # ------------------------
       # agreement_signed_by_all case
       # ------------------------
       agreement_signed_by_all_items = MailActionItem.for_user(user_id)

--- a/app/libs/services/employer_actions/resolver.rb
+++ b/app/libs/services/employer_actions/resolver.rb
@@ -9,7 +9,7 @@ module Services::EmployerActions
         standard_resolver(user_id:, urgency_level:)
       end
 
-      MailActionItem.where(user_id:)
+      MailActionItem.for_user(user_id)
                     .resolved
                     .delete_all
     end
@@ -21,11 +21,9 @@ module Services::EmployerActions
       # new_internship_application case
       # ------------------------
       # application which aasm_state is not :submitted are to be set as resolved
-      actions = MailActionItem.where(
-        user_id:,
-        urgency_level:,
-        action_name: "new_internship_application"
-      )
+      actions = MailActionItem.for_user(user_id)
+                              .where(urgency_level:)
+                              .where(action_name: "new_internship_application")
       if actions.present?
         actions.each do |mail_action_item|
           if mail_action_item&.internship_application&.aasm_state != "submitted"
@@ -37,11 +35,9 @@ module Services::EmployerActions
       # ------------------------
       # canceled_internship_application_by_student case
       # ------------------------
-      actions = MailActionItem.where(
-        user_id:,
-        urgency_level:,
-        action_name: "canceled_internship_application_by_student"
-      )
+      actions = MailActionItem.for_user(user_id)
+                              .where(urgency_level:)
+                              .where(action_name: "canceled_internship_application_by_student")
       actions.present? && actions.each do |item|
         if item&.internship_application&.canceled_by_student_confirmation?
           application_resolve(item.internship_application)
@@ -51,11 +47,9 @@ module Services::EmployerActions
       # ------------------------
       # restored_internship_application case
       # ------------------------
-      actions = MailActionItem.where(
-        user_id:,
-        urgency_level:,
-        action_name: "restored_internship_application"
-      )
+      actions = MailActionItem.for_user(user_id)
+                              .where(urgency_level:)
+                              .where(action_name: "restored_internship_application")
       actions.present? && actions.each do |item|
         if item&.internship_application&.aasm_state != "restored"
           application_resolve(item.internship_application)
@@ -65,8 +59,7 @@ module Services::EmployerActions
       # ------------------------
       # cancel_by_student_confirmation case
       # ------------------------
-      actions = MailActionItem.where(
-        user_id:,
+      actions = MailActionItem.for_user(user_id).where(
         urgency_level:,
         action_name: "cancel_by_student_confirmation"
       )
@@ -83,11 +76,9 @@ module Services::EmployerActions
       # ------------------------
       # agreement_signed_by_all case
       # ------------------------
-      agreement_signed_by_all_items = MailActionItem.where(
-        user_id:,
-        urgency_level:,
-        action_name: "agreement_signed_by_all"
-      )
+      agreement_signed_by_all_items = MailActionItem.for_user(user_id)
+                                                    .where(urgency_level:)
+                                                    .where(action_name: "agreement_signed_by_all")
       agreement_signed_by_all_items.present? && agreement_signed_by_all_items.each do |item|
         agreement_resolve(item.internship_agreement)
       end
@@ -95,11 +86,9 @@ module Services::EmployerActions
       # ------------------------
       # agreement_to_sign case
       # ------------------------
-      agreement_to_sign_items = MailActionItem.where(
-        user_id:,
-        urgency_level:,
-        action_name: "agreement_to_sign"
-      )
+      agreement_to_sign_items = MailActionItem.for_user(user_id)
+                                              .where(urgency_level:)
+                                              .where(action_name: "agreement_to_sign")
       agreement_to_sign_items.present? && agreement_to_sign_items.each do |item|
         if item&.internship_agreement&.roles_not_signed_yet&.exclude?("employer")
           agreement_resolve(item.internship_agreement)
@@ -108,7 +97,7 @@ module Services::EmployerActions
     end
 
     def self.standard_resolver(user_id:, urgency_level:)
-      mail_action_items_base = MailActionItem.where(user_id:)
+      mail_action_items_base = MailActionItem.for_user(user_id)
                                              .where(urgency_level: urgency_level)
       # Only delete stale or over-delivered items, not items just resolved
       mail_action_items_base.where("stale_at < ?", Time.current)

--- a/app/mailers/employer_actions_mailer.rb
+++ b/app/mailers/employer_actions_mailer.rb
@@ -105,9 +105,23 @@ class EmployerActionsMailer < ApplicationMailer
       }
     end
 
-    # --- Agreement to sign / fill ---
-    @agreement_to_sign_rows = all_agreements
-      .select { |item| item.action_name == "agreement_to_sign" }
+    # --- Agreement to sign ---
+    @agreement_to_fill_in_rows = all_agreements.select { |item| %w[agreement_to_sign].include?(item.action_name) }
+                                               .filter_map do |item|
+      internship_application = item.internship_application
+      next if internship_application.nil?
+
+      agreement = internship_application.internship_agreement
+      {
+        student_full_name: internship_application.student.presenter.full_name,
+        offer_title:       internship_application.internship_offer.title,
+        agreement_url:     agreement ? edit_dashboard_internship_agreement_url(uuid: agreement.uuid) : dashboard_internship_offers_url
+      }
+    end
+
+    # --- Agreement to fill in ---
+    @agreement_to_fill_in_rows = all_agreements
+      .select { |item| %w[ new_agreement_to_fill_in].include?(item.action_name) }
       .filter_map do |item|
       internship_application = item.internship_application
       next if internship_application.nil?

--- a/app/models/concerns/mail_action_configurable.rb
+++ b/app/models/concerns/mail_action_configurable.rb
@@ -44,6 +44,10 @@ module MailActionConfigurable
     }.transform_values { |v| v.merge(action_type: :pending_internship_application) }.freeze
 
     PENDING_AGREEMENT_CONFIGS = {
+      "new_agreement_to_fill_in" => {
+        urgency_level: "medium",
+        max_deliveries_count: 2
+      },
       "agreement_signed_by_another" => {
         urgency_level: "low",
         max_deliveries_count: 1

--- a/app/models/internship_agreement.rb
+++ b/app/models/internship_agreement.rb
@@ -310,7 +310,7 @@ class InternshipAgreement < ApplicationRecord
   private
 
   def notify_employer_with_digest_email(name, **kwargs)
-    kwargs[:user_id] ||= internship_application.internship_offer.employer_id
+    kwargs[:recipient] ||= internship_application.internship_offer.employer
     kwargs[:internship_agreement_id] ||= id
     kwargs[:action_type] ||= :pending_internship_agreement
     kwargs[:stale_at] ||= internship_application.weeks&.order(:year, :number)&.last&.monday || 30.days.from_now

--- a/app/models/internship_application.rb
+++ b/app/models/internship_application.rb
@@ -547,7 +547,7 @@ class InternshipApplication < ApplicationRecord
     notify_employer_with_digest_email(
       "new_agreement_to_fill_in",
       internship_agreement_id: agreement.id,
-      action_type: :agreement_to_complete
+      action_type: :pending_internship_agreement
     )
   end
 
@@ -562,7 +562,7 @@ class InternshipApplication < ApplicationRecord
     notify_employer_with_digest_email(
       "new_agreement_to_fill_in",
       internship_agreement_id: agreement.id,
-      action_type: :agreement_to_complete
+      action_type: :pending_internship_agreement
     )
   end
 

--- a/app/models/internship_application.rb
+++ b/app/models/internship_application.rb
@@ -420,7 +420,7 @@ class InternshipApplication < ApplicationRecord
   end
 
   def notify_employer_with_digest_email(name, **kwargs)
-    kwargs[:user_id] ||= internship_offer.employer_id
+    kwargs[:recipient] ||= internship_offer.employer
     kwargs[:internship_application_id] ||= id
     kwargs[:internship_agreement_id] ||= internship_agreement.id if internship_agreement&.persisted?
     kwargs[:action_type] ||= :pending_internship_application

--- a/app/models/internship_application.rb
+++ b/app/models/internship_application.rb
@@ -428,6 +428,20 @@ class InternshipApplication < ApplicationRecord
     MailActionItem.create_by_name!(name, **kwargs)
   end
 
+  def notify_school_management_with_digest_email(name, **kwargs)
+    school_representative = student.school.management_representative
+    if school_representative.nil?
+      Rails.logger.error("No management representative found for school ##{student.school.id}")
+      return
+    end
+    kwargs[:recipient] ||= school_representative
+    kwargs[:internship_application_id] ||= id
+    kwargs[:internship_agreement_id] ||= internship_agreement.id if internship_agreement&.persisted?
+    kwargs[:action_type] ||= :pending_internship_application
+    kwargs[:stale_at] ||= weeks.order(:year, :number).last.monday - 2.days
+    MailActionItem.create_by_name!(name, **kwargs)
+  end
+
   def multi?
     internship_offer.from_multi?
   end
@@ -531,9 +545,9 @@ class InternshipApplication < ApplicationRecord
     agreement.save!
 
     notify_employer_with_digest_email(
-      "agreement_to_sign",
+      "new_agreement_to_fill_in",
       internship_agreement_id: agreement.id,
-      action_type: :pending_internship_agreement
+      action_type: :agreement_to_complete
     )
   end
 
@@ -545,9 +559,11 @@ class InternshipApplication < ApplicationRecord
     agreement.skip_validations_for_system = true
     agreement.save!
     # TODO notify coordinator and employers
-    EmployerMailer.internship_application_approved_with_agreement_email(
-      internship_agreement:,
-    ).deliver_later
+    notify_employer_with_digest_email(
+      "new_agreement_to_fill_in",
+      internship_agreement_id: agreement.id,
+      action_type: :agreement_to_complete
+    )
   end
 
   def internship_application_counter_hook

--- a/app/models/mail_action_item.rb
+++ b/app/models/mail_action_item.rb
@@ -2,12 +2,12 @@ class MailActionItem < ApplicationRecord
   include MailActionConfigurable
 
   # Associations
-  belongs_to :user
+  belongs_to :recipient, polymorphic: true
   belongs_to :internship_offer, optional: true
   belongs_to :internship_application, optional: true
   belongs_to :internship_agreement, optional: true
   # validations
-  validates_presence_of :user_id,
+  validates_presence_of :recipient_id, :recipient_type,
                         :action_type
   # enums
   enum :action_type, {
@@ -30,12 +30,14 @@ class MailActionItem < ApplicationRecord
   scope :with_action_type, ->(type) { where(action_type: type) }
   scope :with_urgency_level, ->(level) { where(urgency_level: level) }
   scope :with_urgency_levels, ->(levels) { where(urgency_level: levels) }
-  scope :for_user, ->(user_id) { where(user_id: user_id) }
+  scope :for_recipient, ->(recipient) { where(recipient: recipient) }
+  scope :for_users, -> { where(recipient_type: "User") }
+  scope :for_user, ->(user_id) { where(recipient_type: "User", recipient_id: user_id) }
 
   def self.create_by_name!(name, **kwargs)
     config = ACTION_CONFIGS.fetch(name) { raise ArgumentError, "Unknown MailActionItem name: #{name}" }
     attrs = config.transform_values { |v| v.respond_to?(:call) ? v.call : v }
-    allowed_keys = %i[user user_id internship_offer internship_offer_id
+    allowed_keys = %i[recipient internship_offer internship_offer_id
                       internship_application internship_application_id
                       internship_agreement internship_agreement_id stale_at]
     attrs.merge!(kwargs.slice(*allowed_keys))
@@ -46,7 +48,7 @@ class MailActionItem < ApplicationRecord
 
   # class methods
   def self.involved_user_ids
-    pluck(:user_id).uniq
+    where(recipient_type: "User").pluck(:recipient_id).uniq
   end
   # instance methods
 

--- a/app/models/mail_action_item.rb
+++ b/app/models/mail_action_item.rb
@@ -7,7 +7,8 @@ class MailActionItem < ApplicationRecord
   belongs_to :internship_application, optional: true
   belongs_to :internship_agreement, optional: true
   # validations
-  validates_presence_of :recipient_id, :recipient_type,
+  validates_presence_of :recipient_id,
+                        :recipient_type,
                         :action_type
   # enums
   enum :action_type, {
@@ -32,7 +33,17 @@ class MailActionItem < ApplicationRecord
   scope :with_urgency_levels, ->(levels) { where(urgency_level: levels) }
   scope :for_recipient, ->(recipient) { where(recipient: recipient) }
   scope :for_users, -> { where(recipient_type: "User") }
-  scope :for_user, ->(user_id) { where(recipient_type: "User", recipient_id: user_id) }
+  scope :for_user, ->(user_id) { where(recipient_id: user_id) }
+  scope :for_employers, -> { where(recipient_type: "Users::Employer") }
+  scope :for_employer, ->(employer_id) { where(recipient_type: "Users::Employer", recipient_id: employer_id) }
+  scope :for_school_management_team, -> { where(recipient_type: "Users::SchoolManagement") }
+  scope :for_school_management, ->(school_management_id) {
+    where(recipient_type: "Users::SchoolManagement", recipient_id: school_management_id)
+  }
+  scope :for_school_managers, -> do
+    where(recipient_type: "Users::SchoolManagement")
+    .where(recipient_id: Users::SchoolManagement.where(role: :school_manager).pluck(:id))
+  end
 
   def self.create_by_name!(name, **kwargs)
     config = ACTION_CONFIGS.fetch(name) { raise ArgumentError, "Unknown MailActionItem name: #{name}" }

--- a/app/views/mailers/employer_actions_mailer/employer_digest_email.html.slim
+++ b/app/views/mailers/employer_actions_mailer/employer_digest_email.html.slim
@@ -144,12 +144,34 @@ p style=p_cyclop_styles({color: '#000000'})
 						a href=row[:application_url] style="background-color: #000091; color: #ffffff; padding: 8px 16px; text-decoration: none; font-size: 14px;"
 							| Voir la candidature
 
-/ ─── Conventions à remplir ─────────────────────────────────────────────────
+/ ─── Conventions à signer ──────────────────────────────────────────────────
 - if @agreement_to_sign_rows&.any?
+	p style=p_cyclop_styles
+		| Conventions de stage à signer :
+
+	- @agreement_to_sign_rows.each_with_index do |row, index|
+		table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="margin-bottom: 20px; border: 1px solid #dddddd;"
+			tbody
+				tr style="background-color: #000091;"
+					td style="padding: 8px 12px; color: #ffffff; font-size: 16px; font-weight: bold;"
+						= "#{index + 1}. #{row[:student_full_name]}"
+				tr style="background-color: #f6f6f6;"
+					td style="color: #000091; font-size: 14px; padding: 10px 12px;"
+						p style="margin: 0;"
+							strong
+								| Stage :
+							= " #{row[:offer_title]}"
+				tr style="background-color: #ffffff;"
+					td style="padding: 10px 12px; text-align: right;"
+						a href=row[:agreement_url] style="background-color: #000091; color: #ffffff; padding: 8px 16px; text-decoration: none; font-size: 14px;"
+							| Voir la convention
+
+/ ─── Conventions à remplir ─────────────────────────────────────────────────
+- if @agreement_to_fill_in_rows&.any?
 	p style=p_cyclop_styles
 		| Conventions de stage à compléter :
 
-	- @agreement_to_sign_rows.each_with_index do |row, index|
+	- @agreement_to_fill_in_rows.each_with_index do |row, index|
 		table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="margin-bottom: 20px; border: 1px solid #dddddd;"
 			tbody
 				tr style="background-color: #000091;"

--- a/app/views/mailers/employer_actions_mailer/employer_digest_email.text.erb
+++ b/app/views/mailers/employer_actions_mailer/employer_digest_email.text.erb
@@ -60,10 +60,10 @@ Candidatures transférées :
 <% end %>
 <% end %>
 
-<% if @agreement_to_sign_rows&.any? %>
+<% if @agreement_to_fill_in_rows&.any? %>
 Conventions de stage à compléter :
 
-<% @agreement_to_sign_rows.each_with_index do |row, index| %>
+<% @agreement_to_fill_in_rows.each_with_index do |row, index| %>
 <%= index + 1 %>. <%= row[:student_full_name] %>
 - Stage : <%= row[:offer_title] %>
 - Remplir la convention : <%= row[:agreement_url] %>

--- a/db/migrate/20260515100000_convert_mail_action_item_user_to_polymorphic_recipient.rb
+++ b/db/migrate/20260515100000_convert_mail_action_item_user_to_polymorphic_recipient.rb
@@ -1,0 +1,32 @@
+class ConvertMailActionItemUserToPolymorphicRecipient < ActiveRecord::Migration[8.1]
+  def change
+    # Add polymorphic columns
+    add_column :mail_action_items, :recipient_type, :string
+    add_column :mail_action_items, :recipient_id, :bigint
+
+    # Migrate existing data: all current users become User recipient type
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE mail_action_items SET recipient_type = 'User', recipient_id = user_id WHERE user_id IS NOT NULL"
+      end
+      dir.down do
+        execute "UPDATE mail_action_items SET user_id = recipient_id WHERE recipient_type = 'User'"
+      end
+    end
+
+    # Add not null constraint after data migration
+    change_column_null :mail_action_items, :recipient_type, false
+    change_column_null :mail_action_items, :recipient_id, false
+
+    # Add polymorphic index
+    add_index :mail_action_items, [ :recipient_type, :recipient_id ]
+
+    # Replace old index with new one
+    remove_index :mail_action_items, name: "index_mail_action_items_on_user_and_action_urgency_resolved"
+    add_index :mail_action_items, [ :recipient_type, :recipient_id, :action_type, :urgency_level, :resolved_at ],
+              name: "index_mail_action_items_on_recipient_pl_action_urgency_resolved"
+
+    # Remove old user_id column
+    remove_column :mail_action_items, :user_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1652,7 +1652,6 @@ ALTER SEQUENCE public.letter_thief_email_messages_id_seq OWNED BY public.letter_
 CREATE TABLE public.mail_action_items (
     id bigint NOT NULL,
     action_name character varying,
-    user_id bigint NOT NULL,
     first_seen_at timestamp(6) without time zone,
     stale_at timestamp(6) without time zone,
     last_notified_at timestamp(6) without time zone,
@@ -1666,7 +1665,9 @@ CREATE TABLE public.mail_action_items (
     urgency_level public.urgency_level,
     internship_offer_id bigint,
     internship_application_id bigint,
-    internship_agreement_id bigint
+    internship_agreement_id bigint,
+    recipient_type character varying NOT NULL,
+    recipient_id bigint NOT NULL
 );
 
 
@@ -4400,17 +4401,17 @@ CREATE INDEX index_mail_action_items_on_internship_offer_id ON public.mail_actio
 
 
 --
--- Name: index_mail_action_items_on_user_and_action_urgency_resolved; Type: INDEX; Schema: public; Owner: -
+-- Name: index_mail_action_items_on_recipient_pl_action_urgency_resolved; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_mail_action_items_on_user_and_action_urgency_resolved ON public.mail_action_items USING btree (user_id, action_type, urgency_level, resolved_at);
+CREATE INDEX index_mail_action_items_on_recipient_pl_action_urgency_resolved ON public.mail_action_items USING btree (recipient_type, recipient_id, action_type, urgency_level, resolved_at);
 
 
 --
--- Name: index_mail_action_items_on_user_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_mail_action_items_on_recipient_type_and_recipient_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_mail_action_items_on_user_id ON public.mail_action_items USING btree (user_id);
+CREATE INDEX index_mail_action_items_on_recipient_type_and_recipient_id ON public.mail_action_items USING btree (recipient_type, recipient_id);
 
 
 --
@@ -5225,14 +5226,6 @@ ALTER TABLE ONLY public.internship_application_weeks
 
 
 --
--- Name: mail_action_items fk_rails_6b318b418e; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.mail_action_items
-    ADD CONSTRAINT fk_rails_6b318b418e FOREIGN KEY (user_id) REFERENCES public.users(id);
-
-
---
 -- Name: users fk_rails_6bdbc6c887; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5607,6 +5600,7 @@ ALTER TABLE ONLY public.mail_action_items
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260515100000'),
 ('20260507100000'),
 ('20260505040224'),
 ('20260504130000'),

--- a/lib/tasks/digest_mails/launch_emails.rake
+++ b/lib/tasks/digest_mails/launch_emails.rake
@@ -1,10 +1,11 @@
 namespace :digest_mailers do
   desc "send digest mails for low urgency level"
   task send_low_urgency_emails: :environment do
-    user_ids = MailActionItem.with_urgency_levels(%w[low medium high critical])
+    user_ids = MailActionItem.for_users
+                             .with_urgency_levels(%w[low medium high critical])
                              .not_overdue
                              .pending
-                             .pluck(:user_id)
+                             .pluck(:recipient_id)
                              .uniq
     if user_ids.any?
       user_ids.each do |user_id|
@@ -19,10 +20,11 @@ namespace :digest_mailers do
 
   desc "send digest mails for medium urgency level"
   task send_medium_urgency_emails: :environment do
-    user_ids = MailActionItem.with_urgency_levels(%w[medium high critical])
+    user_ids = MailActionItem.for_users
+                             .with_urgency_levels(%w[medium high critical])
                              .not_overdue
                              .pending
-                             .pluck(:user_id)
+                             .pluck(:recipient_id)
                              .uniq
     if user_ids.any?
       user_ids.each do |user_id|
@@ -37,10 +39,11 @@ namespace :digest_mailers do
 
   desc "send digest mails for high urgency level"
   task send_high_urgency_emails: :environment do
-    user_ids = MailActionItem.with_urgency_levels(%w[high critical])
+    user_ids = MailActionItem.for_users
+                             .with_urgency_levels(%w[high critical])
                              .not_overdue
                              .pending
-                             .pluck(:user_id)
+                             .pluck(:recipient_id)
                              .uniq
     if user_ids.any?
       user_ids.each do |user_id|
@@ -55,10 +58,11 @@ namespace :digest_mailers do
 
   desc "send digest mails for critical urgency level"
   task send_critical_urgency_emails: :environment do
-    user_ids = MailActionItem.with_urgency_level("critical")
+    user_ids = MailActionItem.for_users
+                             .with_urgency_levels(%w[critical])
                              .not_overdue
                              .pending
-                             .pluck(:user_id)
+                             .pluck(:recipient_id)
                              .uniq
     if user_ids.any?
       user_ids.each do |user_id|

--- a/test/controllers/dashboard/internship_offers/internship_applications/update_test.rb
+++ b/test/controllers/dashboard/internship_offers/internship_applications/update_test.rb
@@ -23,7 +23,7 @@ module InternshipOffers::InternshipApplications
       sign_in(student)
 
       assert_mail_action_item_no_direct_email(recipient: internship_offer.employer,
-                         action_name: "agreement_to_sign",
+                         action_name: "new_agreement_to_fill_in",
                          internship_application: internship_application) do
         patch(
           dashboard_internship_offer_internship_application_path(
@@ -384,7 +384,7 @@ module InternshipOffers::InternshipApplications
       sign_in(student)
 
       assert_mail_action_item_no_direct_email(recipient: internship_offer.employer,
-                                              action_name: "agreement_to_sign",
+                                              action_name: "new_agreement_to_fill_in",
                                               internship_application: internship_application) do
         assert_changes -> { MailActionItem.all.count },
                        from: 0,

--- a/test/controllers/dashboard/internship_offers/internship_applications/update_test.rb
+++ b/test/controllers/dashboard/internship_offers/internship_applications/update_test.rb
@@ -22,7 +22,7 @@ module InternshipOffers::InternshipApplications
       assert school.school_manager.present?
       sign_in(student)
 
-      assert_mail_action_item_no_direct_email(user: internship_offer.employer,
+      assert_mail_action_item_no_direct_email(recipient: internship_offer.employer,
                          action_name: "agreement_to_sign",
                          internship_application: internship_application) do
         patch(
@@ -383,7 +383,7 @@ module InternshipOffers::InternshipApplications
 
       sign_in(student)
 
-      assert_mail_action_item_no_direct_email(user: internship_offer.employer,
+      assert_mail_action_item_no_direct_email(recipient: internship_offer.employer,
                                               action_name: "agreement_to_sign",
                                               internship_application: internship_application) do
         assert_changes -> { MailActionItem.all.count },
@@ -500,7 +500,7 @@ module InternshipOffers::InternshipApplications
       assert_equal "OK", internship_application.canceled_by_student_message
       assert internship_application.canceled_by_student?
       assert_mail_action_item_created_for(
-        user: internship_application.internship_offer.employer,
+        recipient: internship_application.internship_offer.employer,
         action_name: "canceled_internship_application_by_student",
         internship_application: internship_application
       )
@@ -541,7 +541,7 @@ module InternshipOffers::InternshipApplications
 
       sign_in(internship_application.student)
 
-      assert_mail_action_item_no_direct_email(user: internship_application.internship_offer.employer,
+      assert_mail_action_item_no_direct_email(recipient: internship_application.internship_offer.employer,
                          action_name: "restored_internship_application",
                          internship_application: internship_application) do
         patch(

--- a/test/factories/internship_applications.rb
+++ b/test/factories/internship_applications.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
                to_state: "submitted",
                author: application.student)
         create(:mail_action_item,
-               user: application.internship_offer.employer,
+               recipient: application.internship_offer.employer,
                action_name: "new_internship_application",
                action_type: :pending_internship_application,
                urgency_level: :medium,
@@ -52,7 +52,7 @@ FactoryBot.define do
                to_state: "restored",
                author: application.student)
         create(:mail_action_item,
-               user: application.internship_offer.employer,
+               recipient: application.internship_offer.employer,
                action_name: "restored_internship_application",
                action_type: :pending_internship_application,
                urgency_level: :medium,
@@ -129,7 +129,7 @@ FactoryBot.define do
           create(:mono_internship_agreement, internship_application: application)
         end
         create(:mail_action_item,
-          user: application.internship_offer.employer,
+          recipient: application.internship_offer.employer,
           action_name: "agreement_to_sign",
           action_type: :pending_internship_agreement,
           urgency_level: :medium,

--- a/test/factories/mail_action_items.rb
+++ b/test/factories/mail_action_items.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :mail_action_item do
     internship_application { nil }
     internship_agreement { nil }
-    user { internship_application&.internship_offer&.employer || create(:employer) }
+    recipient { internship_application&.internship_offer&.employer || create(:employer) }
     action_name { "default_action" }
     action_type { :pending_internship_application }
     urgency_level { :medium }

--- a/test/lib/services/employer_actions/action_list_test.rb
+++ b/test/lib/services/employer_actions/action_list_test.rb
@@ -7,7 +7,7 @@ module Services
         employer = create(:employer)
 
         valid_medium = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "new_internship_application",
           action_type: :pending_internship_application,
           urgency_level: :medium,
@@ -19,7 +19,7 @@ module Services
         )
 
         MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "new_internship_application",
           action_type: :pending_internship_application,
           urgency_level: :medium,
@@ -31,7 +31,7 @@ module Services
         )
 
         MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "new_internship_application",
           action_type: :pending_internship_application,
           urgency_level: :medium,
@@ -43,7 +43,7 @@ module Services
         )
 
         valid_low = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "new_internship_application",
           action_type: :pending_internship_application,
           urgency_level: :low,
@@ -75,7 +75,7 @@ module Services
         employer = create(:employer)
 
         medium_item = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "new_internship_application",
           action_type: :pending_internship_application,
           urgency_level: :medium,
@@ -87,7 +87,7 @@ module Services
         )
 
         low_item = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "new_internship_application",
           action_type: :pending_internship_application,
           urgency_level: :low,

--- a/test/lib/services/employer_actions/digest_builder_test.rb
+++ b/test/lib/services/employer_actions/digest_builder_test.rb
@@ -7,7 +7,7 @@ module Services
         employer = create(:employer)
 
         item = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "new_internship_application",
           action_type: :pending_internship_application,
           urgency_level: :medium,

--- a/test/lib/services/employer_actions/employer_digest_mailer_test.rb
+++ b/test/lib/services/employer_actions/employer_digest_mailer_test.rb
@@ -7,7 +7,7 @@ module Services
         employer = create(:employer)
 
         kept = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "internship_offer_removed",
           action_type: :pending_internship_offer,
           urgency_level: :medium,
@@ -18,7 +18,7 @@ module Services
         )
 
         MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "internship_offer_removed",
           action_type: :pending_internship_offer,
           urgency_level: :medium,
@@ -29,7 +29,7 @@ module Services
         )
 
         MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "internship_offer_removed",
           action_type: :pending_internship_offer,
           urgency_level: :medium,
@@ -40,7 +40,7 @@ module Services
         )
 
         MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "internship_offer_removed",
           action_type: :pending_internship_offer,
           urgency_level: :medium,
@@ -56,7 +56,7 @@ module Services
         )
 
         assert_equal [ kept.id ],
-                     MailActionItem.where(user: employer).pluck(:id)
+                     MailActionItem.where(recipient: employer).pluck(:id)
       end
 
       test "#find_actions filters out empty action groups" do
@@ -98,7 +98,7 @@ module Services
         MailActionItem.delete_all
 
         item = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "canceled_internship_application_by_student",
           action_type: :pending_internship_application,
           internship_application:,
@@ -112,7 +112,7 @@ module Services
         Services::EmployerActions::EmployerDigestMailer.perform_for_medium_level(user_id: employer.id)
 
         assert_equal [ item.id ],
-                     MailActionItem.where(user: employer, deliveries_count: 1).pluck(:id)
+                     MailActionItem.where(recipient: employer, deliveries_count: 1).pluck(:id)
       end
 
       test ".perform_for_medium_level delivers for restored_internship_application" do
@@ -121,7 +121,7 @@ module Services
         MailActionItem.delete_all
 
         item = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "restored_internship_application",
           action_type: :pending_internship_application,
           internship_application:,
@@ -135,7 +135,7 @@ module Services
         Services::EmployerActions::EmployerDigestMailer.perform_for_medium_level(user_id: employer.id)
 
         assert_equal [ item.id ],
-                     MailActionItem.where(user: employer, deliveries_count: 1).pluck(:id)
+                     MailActionItem.where(recipient: employer, deliveries_count: 1).pluck(:id)
       end
 
       test ".perform_for_high_level delivers for cancel_by_student_confirmation" do
@@ -144,7 +144,7 @@ module Services
         MailActionItem.delete_all
 
         item = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "cancel_by_student_confirmation",
           action_type: :pending_internship_application,
           internship_application:,
@@ -158,7 +158,7 @@ module Services
         Services::EmployerActions::EmployerDigestMailer.perform_for_high_level(user_id: employer.id)
 
         assert_equal [ item.id ],
-                     MailActionItem.where(user: employer, deliveries_count: 1).pluck(:id)
+                     MailActionItem.where(recipient: employer, deliveries_count: 1).pluck(:id)
       end
 
       test "#perform_for_low_level performs expected operations" do
@@ -167,7 +167,7 @@ module Services
         MailActionItem.delete_all
 
         valid_medium = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "new_internship_application",
           action_type: :pending_internship_application,
           internship_application:,
@@ -181,7 +181,7 @@ module Services
         Services::EmployerActions::EmployerDigestMailer.perform_for_medium_level(user_id: employer.id)
 
         assert_equal [ valid_medium.id ],
-                     MailActionItem.where(user: employer, deliveries_count: 1).pluck(:id)
+                     MailActionItem.where(recipient: employer, deliveries_count: 1).pluck(:id)
       end
     end
   end

--- a/test/lib/services/employer_actions/employer_digest_mailer_test.rb
+++ b/test/lib/services/employer_actions/employer_digest_mailer_test.rb
@@ -95,6 +95,7 @@ module Services
       test ".perform_for_medium_level delivers for canceled_internship_application_by_student" do
         internship_application = create(:weekly_internship_application)
         employer = internship_application.internship_offer.employer
+        internship_application.update_columns(aasm_state: "canceled_by_student")
         MailActionItem.delete_all
 
         item = MailActionItem.create!(
@@ -141,6 +142,7 @@ module Services
       test ".perform_for_high_level delivers for cancel_by_student_confirmation" do
         internship_application = create(:weekly_internship_application, :submitted)
         employer = internship_application.internship_offer.employer
+        internship_application.update_columns(aasm_state: "canceled_by_student_confirmation")
         MailActionItem.delete_all
 
         item = MailActionItem.create!(

--- a/test/lib/services/employer_actions/resolver_test.rb
+++ b/test/lib/services/employer_actions/resolver_test.rb
@@ -11,7 +11,7 @@ module Services
         internship_application = create(:weekly_internship_application, :approved)
 
         item = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "new_internship_application",
           action_type: :pending_internship_application,
           urgency_level: :medium,
@@ -32,7 +32,7 @@ module Services
         internship_application = create(:weekly_internship_application)
 
         item = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "new_internship_application",
           action_type: :pending_internship_application,
           urgency_level: :medium,
@@ -57,7 +57,7 @@ module Services
         internship_agreement.discard!
 
         item = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "agreement_signed_by_all",
           action_type: :pending_internship_agreement,
           urgency_level: :medium,
@@ -77,7 +77,7 @@ module Services
         employer = create(:employer)
 
         item = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "agreement_signed_by_all",
           action_type: :pending_internship_agreement,
           urgency_level: :medium,
@@ -98,7 +98,7 @@ module Services
         internship_agreement = create(:mono_internship_agreement, :signed_by_all)
 
         item = MailActionItem.create!(
-          user: employer,
+          recipient: employer,
           action_name: "agreement_signed_by_all",
           action_type: :pending_internship_agreement,
           urgency_level: :medium,

--- a/test/lib/tasks/digest_mails/low_test.rb
+++ b/test/lib/tasks/digest_mails/low_test.rb
@@ -36,7 +36,7 @@ class DigestMailslowTest < ActiveSupport::TestCase
     MailActionItem.delete_all
 
     MailActionItem.create!(
-      user: employer,
+      recipient: employer,
       action_name: "new_internship_application",
       action_type: :pending_internship_application,
       urgency_level: :low,
@@ -48,7 +48,7 @@ class DigestMailslowTest < ActiveSupport::TestCase
     )
 
     MailActionItem.create!(
-      user: employer,
+      recipient: employer,
       action_name: "new_internship_application",
       action_type: :pending_internship_application,
       urgency_level: :low,

--- a/test/mailers/employer_actions_mailer_test.rb
+++ b/test/mailers/employer_actions_mailer_test.rb
@@ -162,4 +162,42 @@ class EmployerActionsMailerTest < ActionMailer::TestCase
     assert_match student.school.name, text_body
     assert_match "Voir la convention", text_body
   end
+
+  test "digest_email renders new_agreement_to_fill_in rows in agreement section" do
+    employer = create(:employer)
+    internship_agreement = create(:mono_internship_agreement, :draft)
+    internship_application = internship_agreement.internship_application
+
+    item = MailActionItem.create!(
+      recipient: employer,
+      action_name: "new_agreement_to_fill_in",
+      action_type: :pending_internship_agreement,
+      urgency_level: :medium,
+      stale_at: 30.days.from_now,
+      resolved_at: nil,
+      deliveries_count: 0,
+      max_deliveries_count: 2,
+      internship_application: internship_application,
+      internship_agreement: internship_agreement
+    )
+
+    actions = { "pending_internship_agreement" => [ item ] }
+
+    email = EmployerActionsMailer.employer_digest_email(user_id: employer.id, actions: actions, urgency_levels: [ "medium" ])
+    email.deliver_now
+
+    assert_emails 1
+    assert_includes email.to, employer.email
+
+    html_body = email.html_part.body.to_s
+    text_body = email.text_part.body.to_s
+
+    assert_match "Conventions de stage à compléter", html_body
+    assert_match internship_application.student.presenter.full_name, html_body
+    assert_match "Remplir la convention", html_body
+
+    assert_match "Conventions de stage à compléter", text_body
+    assert_match internship_application.student.presenter.full_name, text_body
+    assert_match "Remplir la convention", text_body
+  end
 end

--- a/test/mailers/employer_actions_mailer_test.rb
+++ b/test/mailers/employer_actions_mailer_test.rb
@@ -11,7 +11,7 @@ class EmployerActionsMailerTest < ActionMailer::TestCase
     internship_application = create(:weekly_internship_application)
 
     item = MailActionItem.create!(
-      user: employer,
+      recipient: employer,
       action_name: "new_internship_application",
       action_type: :pending_internship_application,
       urgency_level: :medium,
@@ -43,7 +43,7 @@ class EmployerActionsMailerTest < ActionMailer::TestCase
     internship_agreement = create(:mono_internship_agreement, :signed_by_all)
 
     item = MailActionItem.create!(
-      user: employer,
+      recipient: employer,
       action_name: "agreement_signed_by_all",
       action_type: :pending_internship_agreement,
       urgency_level: :low,
@@ -80,7 +80,7 @@ class EmployerActionsMailerTest < ActionMailer::TestCase
     internship_application = create(:weekly_internship_application)
 
     item = MailActionItem.create!(
-      user: employer,
+      recipient: employer,
       action_name: "new_internship_application",
       action_type: :pending_internship_application,
       urgency_level: :medium,
@@ -104,7 +104,7 @@ class EmployerActionsMailerTest < ActionMailer::TestCase
     employer = create(:employer)
 
     item = MailActionItem.create!(
-      user: employer,
+      recipient: employer,
       action_name: "agreement_signed_by_all",
       action_type: :pending_internship_agreement,
       urgency_level: :low,
@@ -129,7 +129,7 @@ class EmployerActionsMailerTest < ActionMailer::TestCase
     internship_agreement = create(:mono_internship_agreement, :validated)
 
     item = MailActionItem.create!(
-      user: employer,
+      recipient: employer,
       action_name: "signatures_enabled",
       action_type: :pending_internship_agreement,
       urgency_level: :medium,

--- a/test/mailers/employer_mailer_test.rb
+++ b/test/mailers/employer_mailer_test.rb
@@ -138,7 +138,7 @@ class EmployerMailerTest < ActionMailer::TestCase
                     .update(notify: false)
 
     internship_application.restore!
-    assert MailActionItem.where(user: employer,
+    assert MailActionItem.where(recipient: employer,
                                 action_name: "restored_internship_application",
                                 internship_application: internship_application)
                          .exists?

--- a/test/models/internship_agreement_test.rb
+++ b/test/models/internship_agreement_test.rb
@@ -149,7 +149,7 @@ class InternshipAgreementTest < ActiveSupport::TestCase
     item = MailActionItem.last
     assert_equal "agreement_signed_by_all", item.action_name
     assert_equal "pending_internship_agreement", item.action_type
-    assert_equal employer.id, item.user_id
+    assert_equal employer, item.recipient
     assert_equal internship_agreement.id, item.internship_agreement_id
     assert_equal "medium", item.urgency_level
     assert_equal 1, item.max_deliveries_count

--- a/test/models/internship_application_test.rb
+++ b/test/models/internship_application_test.rb
@@ -200,7 +200,7 @@ class InternshipApplicationTest < ActiveSupport::TestCase
     assert_difference "MailActionItem.count", 1 do
       internship_application.approve!
     end
-    assert_equal "agreement_to_sign", MailActionItem.last.action_name
+    assert_equal "new_agreement_to_fill_in", MailActionItem.last.action_name
   end
 
   test "transition from submited to approved sends an email to school_manager when no agreement is possible" do

--- a/test/models/mail_action_item_test.rb
+++ b/test/models/mail_action_item_test.rb
@@ -9,7 +9,7 @@ class MailActionItemTest < ActiveSupport::TestCase
 
   test ".create_by_name! raises ArgumentError for unknown name" do
     assert_raises(ArgumentError) do
-      MailActionItem.create_by_name!("unknown_action", user: @employer)
+      MailActionItem.create_by_name!("unknown_action", recipient: @employer)
     end
   end
 
@@ -17,7 +17,7 @@ class MailActionItemTest < ActiveSupport::TestCase
   MailActionItem::ACTION_CONFIGS.each do |action_name, config|
     test ".create_by_name! with #{action_name} sets correct defaults" do
       freeze_time do
-        item = MailActionItem.create_by_name!(action_name, user: @employer)
+        item = MailActionItem.create_by_name!(action_name, recipient: @employer)
         assert item.persisted?, "expected record to be saved"
         assert_equal action_name, item.action_name
         assert_equal config[:action_type].to_s, item.action_type
@@ -29,7 +29,10 @@ class MailActionItemTest < ActiveSupport::TestCase
 
   test ".create_by_name! kwargs override default stale_at" do
     custom_stale_at = 14.days.from_now
-    item = MailActionItem.create_by_name!("new_internship_application", user: @employer, stale_at: custom_stale_at)
+    item = MailActionItem.create_by_name!(
+      "new_internship_application",
+      recipient: @employer,
+      stale_at: custom_stale_at)
     assert_in_delta custom_stale_at, item.stale_at, 5.seconds
   end
 end

--- a/test/support/mail_action_item_helpers.rb
+++ b/test/support/mail_action_item_helpers.rb
@@ -1,23 +1,23 @@
 module MailActionItemHelpers
   UNSPECIFIED_ASSOCIATION = Object.new
 
-  def assert_mail_action_item_created_for(user:, action_name:, internship_application: UNSPECIFIED_ASSOCIATION, internship_agreement: UNSPECIFIED_ASSOCIATION)
-    scope = MailActionItem.where(user:, action_name:)
+  def assert_mail_action_item_created_for(recipient:, action_name:, internship_application: UNSPECIFIED_ASSOCIATION, internship_agreement: UNSPECIFIED_ASSOCIATION)
+    scope = MailActionItem.where(recipient:, action_name:)
     scope = scope.where(internship_application:) unless internship_application.equal?(UNSPECIFIED_ASSOCIATION)
     scope = scope.where(internship_agreement:) unless internship_agreement.equal?(UNSPECIFIED_ASSOCIATION)
 
     assert scope.exists?,
-           "Expected a MailActionItem with action_name '#{action_name}' for user #{user.email} but none was found."
+           "Expected a MailActionItem with action_name '#{action_name}' for recipient #{recipient.email} but none was found."
   end
 
-  def assert_mail_action_item_no_direct_email(user:, action_name:, internship_application: UNSPECIFIED_ASSOCIATION, internship_agreement: UNSPECIFIED_ASSOCIATION, &block)
+  def assert_mail_action_item_no_direct_email(recipient:, action_name:, internship_application: UNSPECIFIED_ASSOCIATION, internship_agreement: UNSPECIFIED_ASSOCIATION, &block)
     MailActionItem.delete_all
     assert_enqueued_emails 0 do
       yield if block_given?
     end
 
     assert_mail_action_item_created_for(
-      user:,
+      recipient:,
       action_name:,
       internship_application:,
       internship_agreement:


### PR DESCRIPTION
- `user` attribute → `recipient` attribute in `MailActionItem`
- Various test files updated to use `recipient:` instead of `user:`
- Helper methods updated accordingly