### PR TITLE
MGF-1734-fix(application approval) : prevent duplicate approvals via DB lock a…

### DIFF
--- a/app/models/internship_application.rb
+++ b/app/models/internship_application.rb
@@ -772,10 +772,13 @@ class InternshipApplication < ApplicationRecord
   end
 
   def no_other_approved_application?
-    others = student.internship_applications.approved.where.not(id: id)
-    return others.empty? unless student.seconde_gt?
+    # Lock the student row to prevent concurrent approvals from bypassing this check
+    student.with_lock do
+      others = student.internship_applications.approved.where.not(id: id)
+      return others.empty? unless student.seconde_gt?
 
-    others.none? { |other| weekly_conflict_with?(other.internship_offer) }
+      others.none? { |other| weekly_conflict_with?(other.internship_offer) }
+    end
   end
 
   def weekly_conflict_with?(other_offer)

--- a/app/models/internship_offer.rb
+++ b/app/models/internship_offer.rb
@@ -435,11 +435,13 @@ class InternshipOffer < ApplicationRecord
   end
 
   def seconde_school_track_week_1?
-    weeks & SchoolTrack::Seconde.both_weeks == [ SchoolTrack::Seconde.first_week ]
+    week_ids = weeks.map(&:id)
+    week_ids.include?(SchoolTrack::Seconde.first_week.id) && !week_ids.include?(SchoolTrack::Seconde.second_week.id)
   end
 
   def seconde_school_track_week_2?
-    weeks & SchoolTrack::Seconde.both_weeks == [ SchoolTrack::Seconde.second_week ]
+    week_ids = weeks.map(&:id)
+    week_ids.include?(SchoolTrack::Seconde.second_week.id) && !week_ids.include?(SchoolTrack::Seconde.first_week.id)
   end
 
   def fits_for_seconde?

--- a/test/models/internship_application_test.rb
+++ b/test/models/internship_application_test.rb
@@ -762,6 +762,41 @@ class InternshipApplicationTest < ActiveSupport::TestCase
     end
   end
 
+  test "concurrent approvals on conflicting weekly offers cannot both succeed" do
+    travel_to Time.zone.local(2025, 3, 1) do
+      school = create(:school, school_type: "lycee")
+      student = create(:student, :seconde, school:)
+      offer_week_1 = create(:weekly_internship_offer_2nde, :week_1)
+      offer_week_1_bis = create(:weekly_internship_offer_2nde, :week_1)
+      application_1 = create(:weekly_internship_application, :validated_by_employer,
+                             student:, internship_offer: offer_week_1)
+      application_2 = create(:weekly_internship_application, :validated_by_employer,
+                             student:, internship_offer: offer_week_1_bis)
+
+      results = []
+      ready = Concurrent::CountDownLatch.new(2)
+      threads = [ application_1, application_2 ].map do |application|
+        Thread.new do
+          ActiveRecord::Base.connection_pool.with_connection do
+            ready.count_down
+            ready.wait
+            results << begin
+              application.approve!
+              :approved
+            rescue AASM::InvalidTransition
+              :rejected
+            end
+          end
+        end
+      end
+      threads.each(&:join)
+
+      assert_equal [ :approved, :rejected ].sort, results.sort
+      approved_count = [ application_1, application_2 ].count { |a| a.reload.aasm_state == "approved" }
+      assert_equal 1, approved_count
+    end
+  end
+
   test "#is_re_approvable? is true for an expired application with no blocker" do
     application = create(:weekly_internship_application, :expired)
 

--- a/test/models/internship_offer_test.rb
+++ b/test/models/internship_offer_test.rb
@@ -132,6 +132,31 @@ class InternshipOfferTest < ActiveSupport::TestCase
     refute internship_offer.two_weeks_long?
   end
 
+  test '.seconde_school_track_week_1? and .seconde_school_track_week_2?' do
+    offer_week_1 = create(:weekly_internship_offer_2nde, :week_1)
+    assert offer_week_1.seconde_school_track_week_1?
+    refute offer_week_1.seconde_school_track_week_2?
+
+    offer_week_2 = create(:weekly_internship_offer_2nde, :week_2)
+    refute offer_week_2.seconde_school_track_week_1?
+    assert offer_week_2.seconde_school_track_week_2?
+
+    offer_both = create(:weekly_internship_offer_2nde, :both_weeks)
+    refute offer_both.seconde_school_track_week_1?
+    refute offer_both.seconde_school_track_week_2?
+  end
+
+  test '.seconde_school_track_week_1? compares week ids, not cached week instances' do
+    offer_week_1 = create(:weekly_internship_offer_2nde, :week_1)
+
+    # Reload offer.weeks through a fresh association so the Week instances are
+    # different object instances than SchoolTrack::Seconde.first_week, but
+    # represent the same record (same id)
+    reloaded_offer = InternshipOffer.find(offer_week_1.id)
+
+    assert reloaded_offer.seconde_school_track_week_1?
+  end
+
   test "factory 'multi'" do
     internship_offer = build(:multi_internship_offer)
     assert internship_offer.valid?


### PR DESCRIPTION
…nd id-based week comparison

Lock the student row during no_other_approved_application? to prevent race conditions where concurrent requests bypass the conflict check. Also fix seconde_school_track_week_1? and week_2? to compare week ids instead of AR object instances, avoiding false negatives caused by different cached instances of the same week